### PR TITLE
AlbumDetailViewController

### DIFF
--- a/ios-albums/ios-albums.xcodeproj/project.pbxproj
+++ b/ios-albums/ios-albums.xcodeproj/project.pbxproj
@@ -9,21 +9,25 @@
 /* Begin PBXBuildFile section */
 		832DC51B2416D20D0012987B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832DC51A2416D20D0012987B /* AppDelegate.swift */; };
 		832DC51D2416D20D0012987B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832DC51C2416D20D0012987B /* SceneDelegate.swift */; };
-		832DC51F2416D20D0012987B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832DC51E2416D20D0012987B /* ViewController.swift */; };
 		832DC5222416D20D0012987B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 832DC5202416D20D0012987B /* Main.storyboard */; };
 		832DC5242416D2140012987B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 832DC5232416D2140012987B /* Assets.xcassets */; };
 		832DC5272416D2140012987B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 832DC5252416D2140012987B /* LaunchScreen.storyboard */; };
+		832DC5302416D3070012987B /* AlbumsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832DC52F2416D3070012987B /* AlbumsTableViewController.swift */; };
+		832DC5322416D8180012987B /* AlbumDetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832DC5312416D8180012987B /* AlbumDetailTableViewController.swift */; };
+		832DC5352416D9940012987B /* SongTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832DC5342416D9940012987B /* SongTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		832DC5172416D20D0012987B /* ios-albums.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ios-albums.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		832DC51A2416D20D0012987B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		832DC51C2416D20D0012987B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		832DC51E2416D20D0012987B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		832DC5212416D20D0012987B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		832DC5232416D2140012987B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		832DC5262416D2140012987B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		832DC5282416D2140012987B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		832DC52F2416D3070012987B /* AlbumsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumsTableViewController.swift; sourceTree = "<group>"; };
+		832DC5312416D8180012987B /* AlbumDetailTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailTableViewController.swift; sourceTree = "<group>"; };
+		832DC5342416D9940012987B /* SongTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,15 +60,33 @@
 		832DC5192416D20D0012987B /* ios-albums */ = {
 			isa = PBXGroup;
 			children = (
+				832DC52E2416D2E70012987B /* ViewControllers */,
 				832DC51A2416D20D0012987B /* AppDelegate.swift */,
 				832DC51C2416D20D0012987B /* SceneDelegate.swift */,
-				832DC51E2416D20D0012987B /* ViewController.swift */,
 				832DC5202416D20D0012987B /* Main.storyboard */,
 				832DC5232416D2140012987B /* Assets.xcassets */,
 				832DC5252416D2140012987B /* LaunchScreen.storyboard */,
 				832DC5282416D2140012987B /* Info.plist */,
 			);
 			path = "ios-albums";
+			sourceTree = "<group>";
+		};
+		832DC52E2416D2E70012987B /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				832DC5332416D9850012987B /* Cells */,
+				832DC52F2416D3070012987B /* AlbumsTableViewController.swift */,
+				832DC5312416D8180012987B /* AlbumDetailTableViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		832DC5332416D9850012987B /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				832DC5342416D9940012987B /* SongTableViewCell.swift */,
+			);
+			path = Cells;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -138,8 +160,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				832DC51F2416D20D0012987B /* ViewController.swift in Sources */,
 				832DC51B2416D20D0012987B /* AppDelegate.swift in Sources */,
+				832DC5302416D3070012987B /* AlbumsTableViewController.swift in Sources */,
+				832DC5352416D9940012987B /* SongTableViewCell.swift in Sources */,
+				832DC5322416D8180012987B /* AlbumDetailTableViewController.swift in Sources */,
 				832DC51D2416D20D0012987B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios-albums/ios-albums/Base.lproj/Main.storyboard
+++ b/ios-albums/ios-albums/Base.lproj/Main.storyboard
@@ -1,24 +1,188 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="IOt-QF-SU3">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="tne-QT-ifu">
+        <!--Albums Table View Controller-->
+        <scene sceneID="IYg-xF-BUp">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                <tableViewController id="4b6-i1-Qh3" customClass="AlbumsTableViewController" customModule="ios_albums" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="p3l-oc-6im">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FirstTVCell" textLabel="z1m-Ya-FPi" detailTextLabel="yED-pb-793" style="IBUITableViewCellStyleSubtitle" id="pfO-4S-8tr">
+                                <rect key="frame" x="0.0" y="28" width="414" height="55.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pfO-4S-8tr" id="5nG-Vb-3ri">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="z1m-Ya-FPi">
+                                            <rect key="frame" x="20" y="10" width="33.5" height="20.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yED-pb-793">
+                                            <rect key="frame" x="20" y="31.5" width="44" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="ZPY-52-K3i" kind="show" id="MrV-Um-cmp"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="4b6-i1-Qh3" id="r12-C1-T0P"/>
+                            <outlet property="delegate" destination="4b6-i1-Qh3" id="0ul-IS-wK4"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="Wdt-vw-LFI">
+                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="Lre-0N-aPv">
+                            <connections>
+                                <segue destination="ZPY-52-K3i" kind="show" id="Vdx-Uh-B9e"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Jhe-Wl-GYU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="1018.840579710145" y="21.428571428571427"/>
+        </scene>
+        <!--Album Detail Table View Controller-->
+        <scene sceneID="05m-TD-Gir">
+            <objects>
+                <tableViewController id="ZPY-52-K3i" customClass="AlbumDetailTableViewController" customModule="ios_albums" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Tj5-zn-e7f">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <view key="tableHeaderView" contentMode="scaleToFill" id="SbX-Vf-t5j">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="214"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="NWX-0w-uVU">
+                                    <rect key="frame" x="20" y="20" width="374" height="174"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Album:" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8ll-JT-78T">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="36"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Artist" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WBE-zU-1YZ">
+                                            <rect key="frame" x="0.0" y="46" width="374" height="36"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Genres seperated by commas:" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O7R-Zb-Cbq">
+                                            <rect key="frame" x="0.0" y="92" width="374" height="36"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Cover URLs seperated by commas:" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rnS-5w-EVH">
+                                            <rect key="frame" x="0.0" y="138" width="374" height="36"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <constraints>
+                                <constraint firstItem="NWX-0w-uVU" firstAttribute="centerY" secondItem="SbX-Vf-t5j" secondAttribute="centerY" id="ZTU-xj-fVs"/>
+                                <constraint firstItem="NWX-0w-uVU" firstAttribute="leading" secondItem="SbX-Vf-t5j" secondAttribute="leading" constant="20" id="pNl-Rt-4Mm"/>
+                                <constraint firstItem="NWX-0w-uVU" firstAttribute="centerX" secondItem="SbX-Vf-t5j" secondAttribute="centerX" id="tOJ-uj-FH9"/>
+                                <constraint firstItem="NWX-0w-uVU" firstAttribute="top" secondItem="SbX-Vf-t5j" secondAttribute="top" constant="20" id="vf2-sX-PY8"/>
+                            </constraints>
+                        </view>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="secondTVCell" rowHeight="140" id="iP9-Xz-HYL" customClass="SongTableViewCell" customModule="ios_albums" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="242" width="414" height="140"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iP9-Xz-HYL" id="mJU-QO-WEr">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="140"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3Wa-Ww-7LO">
+                                            <rect key="frame" x="20" y="11" width="374" height="118"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Song Title:" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VJr-Lc-fp9">
+                                                    <rect key="frame" x="0.0" y="0.0" width="374" height="34"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Duration:" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cTR-de-3kM">
+                                                    <rect key="frame" x="0.0" y="42" width="374" height="34"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EOz-3J-YtB">
+                                                    <rect key="frame" x="0.0" y="84" width="374" height="34"/>
+                                                    <state key="normal" title="Add Song"/>
+                                                    <connections>
+                                                        <action selector="addSongTapped:" destination="iP9-Xz-HYL" eventType="touchUpInside" id="tmv-ao-6VH"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="3Wa-Ww-7LO" firstAttribute="leading" secondItem="mJU-QO-WEr" secondAttribute="leadingMargin" id="4W3-LZ-3Dq"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="3Wa-Ww-7LO" secondAttribute="trailing" id="FUt-mg-p3i"/>
+                                        <constraint firstItem="3Wa-Ww-7LO" firstAttribute="bottom" secondItem="mJU-QO-WEr" secondAttribute="bottomMargin" id="Fdl-vG-n1a"/>
+                                        <constraint firstItem="3Wa-Ww-7LO" firstAttribute="top" secondItem="mJU-QO-WEr" secondAttribute="topMargin" id="SoJ-ox-fbc"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="songDurationTextField" destination="cTR-de-3kM" id="xAd-hV-QsX"/>
+                                    <outlet property="songTitleTxtField" destination="VJr-Lc-fp9" id="DpB-Pc-DDY"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="ZPY-52-K3i" id="S0R-Tg-pGT"/>
+                            <outlet property="delegate" destination="ZPY-52-K3i" id="Ny0-go-QbV"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="cJK-Ar-MYw">
+                        <barButtonItem key="rightBarButtonItem" systemItem="save" id="8hc-dF-Fa2"/>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="nac-zN-VO0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1989.8550724637682" y="20.758928571428569"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="cup-r7-Uwx">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="IOt-QF-SU3" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="mb5-TL-F76">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="4b6-i1-Qh3" kind="relationship" relationship="rootViewController" id="0vf-v4-XpT"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="A31-dq-ApU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="108.69565217391305" y="21.428571428571427"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="MrV-Um-cmp"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/ios-albums/ios-albums/ViewControllers/AlbumDetailTableViewController.swift
+++ b/ios-albums/ios-albums/ViewControllers/AlbumDetailTableViewController.swift
@@ -1,0 +1,90 @@
+//
+//  AlbumDetailTableViewController.swift
+//  ios-albums
+//
+//  Created by Joseph Rogers on 3/9/20.
+//  Copyright © 2020 Casanova Studios. All rights reserved.
+//
+
+import UIKit
+
+class AlbumDetailTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/ios-albums/ios-albums/ViewControllers/Cells/SongTableViewCell.swift
+++ b/ios-albums/ios-albums/ViewControllers/Cells/SongTableViewCell.swift
@@ -1,0 +1,41 @@
+//
+//  SongTableViewCell.swift
+//  ios-albums
+//
+//  Created by Joseph Rogers on 3/9/20.
+//  Copyright © 2020 Casanova Studios. All rights reserved.
+//
+
+import UIKit
+
+class SongTableViewCell: UITableViewCell {
+    
+      //MARK: - Outlets
+    
+    @IBOutlet weak var songTitleTxtField: UITextField!
+    @IBOutlet weak var songDurationTextField: UITextField!
+    
+    
+    
+    //MARK: - Properties
+    
+    //MARK: - Actions
+    
+
+    @IBAction func addSongTapped(_ sender: Any) {
+    }
+    
+    
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}


### PR DESCRIPTION
1. Add a second table view controller scene. Create a show segue from the first table view controller's cell, and another show segue from its bar button item.
2. Add a navigation item to this view controller scene. Then add a bar button item and set its system item to "Save".
3. Add a `UIView` as the detail table view's header view. In this header view, add 4 text fields. The text field's placeholder text should show to the user that they must supply:
    - The album's name.
    - The artist.
    - The genres (separated by commas).
    - URLs to the cover art (separated by commas).
4. Create a Cocoa Touch subclass of `UITableViewController` called `AlbumDetailTableViewController` and set this table view controller's class to it. Create outlets from the four text fields, and an action from the bar button item.
5. Each cell will represent a song. In the prototype cell, add two text fields. The first should take in the song's title, and the second should take in the duration of the song.
6. Add a button in the cell also. This will add the song to the album. Set its title to "Add Song".
7. Create a Cocoa Touch subclass of `UITableViewCell` called `SongTableViewCell` and set this cell's class to it. Create outlets from the text fields and the button. Also create an action from the button.